### PR TITLE
Remove dimension customization

### DIFF
--- a/stattutor/static/html/ctatstudio.html
+++ b/stattutor/static/html/ctatstudio.html
@@ -7,20 +7,6 @@
       </div>
       <span class="tip setting-help">Select one of the available modules and it will be configured properly.</span>
     </li>
-    <li class="field comp-setting-entry is-set">
-      <div class="wrapper-comp-setting">
-        <label class="label setting-label" for="maxwidth">Max Width</label>
-        <input class="input setting-input" name="maxwidth" id="maxwidth" value="{self.width}" type="text" />
-      </div>
-      <span class="tip setting-help">Maximum width of the tutor.</span>
-    </li>
-    <li class="field comp-setting-entry is-set">
-      <div class="wrapper-comp-setting">
-        <label class="label setting-label" for="maxheight">Max Height</label>
-        <input class="input setting-input" name="maxheight" id="maxheight" value="{self.height}" type="text" />
-      </div>
-      <span class="tip setting-help">Maximum height of the tutor.</span>
-    </li>
   </ul>
 
   <div class="xblock-actions">

--- a/stattutor/static/html/ctatxblock.html
+++ b/stattutor/static/html/ctatxblock.html
@@ -1,1 +1,1 @@
-<iframe class="stattutor" src="{tutor_html}" width="{width}" height="{height}"></iframe>
+<iframe class="stattutor" src="{tutor_html}" width="800" height="750"></iframe>

--- a/stattutor/stattutor.py
+++ b/stattutor/stattutor.py
@@ -26,12 +26,6 @@ class StattutorXBlock(XBlock):
         default="StatTutor",
         scope=Scope.content)
 
-    # **** xBlock tag variables ****
-    width = Integer(help="Width of the StatTutor frame.",
-                    default=900, scope=Scope.content)
-    height = Integer(help="Height of the StatTutor frame.",
-                     default=750, scope=Scope.content)
-
     # **** Grading variables ****
     has_score = Boolean(default=True, scope=Scope.content)
     icon_class = String(default="problem", scope=Scope.content)
@@ -155,7 +149,7 @@ class StattutorXBlock(XBlock):
         html = self.resource_string("static/html/ctatxblock.html")
         frag = Fragment(html.format(
             tutor_html=self.get_local_resource_url(self.src),
-            width=self.width, height=self.height))
+        ))
         config = self.resource_string("static/js/CTATConfig.js")
         frag.add_javascript(config.format(
             self=self,
@@ -236,8 +230,6 @@ class StattutorXBlock(XBlock):
         desc = [p for p in problem_dir_files if '.xml' in p]
         if len(desc) > 0:
             self.problem_description = mod_dir+'/'+desc[0]
-        self.width = data.get('width')
-        self.height = data.get('height')
         return {'result': 'success'}
 
     @XBlock.json_handler
@@ -261,7 +253,7 @@ class StattutorXBlock(XBlock):
         return [
             ("StattutorXBlock",
              """<vertical_demo>
-                <stattutor width="900" height="750"/>
+                <stattutor />
                 </vertical_demo>
              """),
         ]


### PR DESCRIPTION
If users are ill-advised to veer from the defaults, we shouldn't let
them shoot themselves in the foot, unless we have some other use-case in mind.

Regardless, dropping the width down from 900px to 800px allows it to fit
within the LMS courseware. From what I see initially, there are no ill
effects. This looks like a win.

This fixes: https://github.com/CMUCTAT/XBlockStattutor/issues/15

Note: This was originally included in #20 . I had originally written these each as individual commits, but I'm explicitly splitting them out now, so that we can independently merge anything that's non-controversial.
