### PR TITLE
Re-enable pylint import errors

### DIFF
--- a/stattutor/stattutor.py
+++ b/stattutor/stattutor.py
@@ -12,6 +12,7 @@ import pkg_resources
 from xblock.core import XBlock
 from xblock.fields import Scope, Integer, String, Float, Boolean
 from xblock.fragment import Fragment
+# pylint: enable=import-error
 
 
 class StattutorXBlock(XBlock):


### PR DESCRIPTION
Yeah, it makes sense to turn it off for XBlock since we know that
dependency is fullfilled elsewhere, but we can turn it right back on
afterward, just in case we add more imports later.

Note: This was originally included in #20 . I had originally written these each as individual commits, but I'm explicitly splitting them out now, so that we can independently merge anything that's non-controversial.
