### PR TITLE
Remove commented-out code

### DIFF
--- a/stattutor/static/html/ctatstudio.html
+++ b/stattutor/static/html/ctatstudio.html
@@ -22,7 +22,6 @@
       <span class="tip setting-help">Maximum height of the tutor.</span>
     </li>
   </ul>
-
   <div class="xblock-actions">
     <ul>
       <li class="action-item">
@@ -34,55 +33,3 @@
     </ul>
   </div>
 </div>
-
-<!--<table cellpadding="0" cellspacing="0" width="100%" height="100%" align="center" valign="middle">
-  <tr>
-    <td align="center" valign="middle">
-
-      <table col=2 class="mainborder">
-	<tr><td colspan="2"><div class="highlightdiv" style="font-weight: bold; font-family: arial;"><b>Tutor Configuration</div></td></tr>
-
-	<tr><td colspan="2"><div class="highlightdiv" style="font-weight: bold; font-family: arial;">Configure DataShop logging (if desired)</div></td></tr>
-
-	<tr><td>logging type:</td>
-	  <td>
-	    <select id="logtype">
-	      <option selected>none</option>
-	      <option>clienttoservice</option>
-	      <option>clienttologserver</option>
-	      <option>servicetologserver</option>
-	      <option>servicetodisk</option>
-	      <option>servicetodiskandlogserver</option>
-	    </select>
-	  </td>
-	</tr>
-
-	<tr><td>problem_name:</td><td><input type="text" id="problem" value="{self.log_name}" size="50" maxlength="50" title="problem name to log"></td></tr>
-	<tr><td>dataset_name: </td><td><input type="text" id="dataset" name="dataset" value="{self.log_dataset}" size="50" maxlength="50" title="dataset name to log"></td></tr>
-	<tr><td>dataset_level_name1: </td><td><input type="text" id="level1" name="level1" value="{self.log_level1}" size="50" maxlength="50" title="level name to log"></td></tr>
-	<tr><td>dataset_level_type1: </td><td><input type="text" id="type1" name="type1" value="{self.log_type1}" size="50" maxlength="50"title="level type to log"></td></tr>
-	<tr><td>dataset_level_name2: </td><td><input type="text" id="level2" name="level2" value="{self.log_level2}" size="50" maxlength="50" title="level name to log"></td></tr>
-	<tr><td>dataset_level_type2: </td><td><input type="text" id="type2" name="type2" value="{self.log_type2}" size="50" maxlength="50"title="level type to log"></td></tr>
-
-	<tr><td>log_service_url: </td><td><input type="text" id="logurl" name="logurl" value="{self.log_url}" size="50" maxlength="150" title="url of the logging service"> </td></tr>
-	<tr><td>sessionlog: </td><td><input type="text" id="slog" name="slog" value="true" size="25" maxlength="25" title="log the session id?"> </td></tr>
-
-	<tr><td colspan="2"><div class="highlightdiv"> <font face="arial"><b>Tutoring Service</b></font></div></td></tr>
-	<tr><td>log_to_disk_directory: </td><td><input type="text" id="diskdir" name="diskdir" value="{self.log_diskdir}" size="25" maxlength="50" title="directory for log files relative to the tutoring service"></td></tr>
-	<tr><td>remotesocketport: </td><td><input type="text" id="port" name="port" value="{self.log_port}" size="25" maxlength="50" title="port used by the tutoring service"></td></tr>
-	<tr><td>remotesocketurl: </td><td><input type="text" id="remoteurl" name="{self.log_remoteurl}" value="localhost" size="50" maxlength="150" title="location of the tutoring service (localhost or domain name)"></td></tr>
-	<tr><td>connection: </td>
-	  <td>
-	    <select id="connection" name="connection">
-	      <option selected>javascript</option>
-	      <option>http</option>
-	      <option>https</option>
-	    </select>
-	  </td>
-	</tr>
-      </table>
-
-    </td>
-  </tr>
-</table>
--->

--- a/stattutor/static/js/Initialize_CTATXBlock.js
+++ b/stattutor/static/js/Initialize_CTATXBlock.js
@@ -5,20 +5,6 @@
  */
 function Initialize_CTATXBlock(runtime,element) {
     var post = {
-	/*set_variable: function(variable_name,value) {
-	    //console.log('CTATXBlock.js','set_variable',variable_name,value);
-	    CTATConfig[variable_name] = value;
-	    var data = {};
-	    data[variable_name] = value;
-	    $.ajax({type: "POST",
-		    url: runtime.handlerUrl(element, 'ctat_set_variable'),
-		    data: JSON.stringify(data),
-		    contentType: "application/json; charset=utf-8",
-		    dataType: "json"})
-		.done(function () {
-		    console.log('ctat_set_variable succeeded');
-		});
-	},*/
 	save_problem_state: function(state) {
 	    $.ajax({type: "POST",
 		    url: runtime.handlerUrl(element, 'ctat_save_problem_state'),
@@ -47,13 +33,10 @@ function Initialize_CTATXBlock(runtime,element) {
 	var lms = this.contentWindow.CTATLMS;
 	lms.identifier = 'XBlock';
 	lms.setValue = function(key,value) {
-	    //console.log('CTATXBlock.setValue',key,value);
-	    //post.set_variable(key,value);
 	    CTATConfig[key]=value;
 	};
 	lms.getValue = function(key) { return CTATConfig[key]; };
 	lms.saveProblemState = function (state) {
-	    //console.log('CTATXBlock','saveProblemState',state);
 	    post.save_problem_state(window.btoa(state.problem_state));
 	};
 	lms.getProblemState = function (handler) {


### PR DESCRIPTION
Static assets like JS and HTML are still sent across the wire to clients,
even if the code is commented out.

Note: This was originally included in #20 . I had originally written these each as individual commits, but I'm explicitly splitting them out now, so that we can independently merge anything that's non-controversial.
