### PR TITLE
Fix for #32

### DIFF
--- a/stattutor/public/problem_files/m4_cell_phones/cell_phones.brd
+++ b/stattutor/public/problem_files/m4_cell_phones/cell_phones.brd
@@ -6838,7 +6838,7 @@
                         <value>UpdateTextArea</value>
                     </Action>
                     <Input>
-                        <value>It would be reasonable to expect that the mean number of sleep hours of students will be lower due to studying or partying…</value>
+                        <value>It would be reasonable to expect that the mean number of sleep hours of students will be lower due to studying or partying&hellip;</value>
                     </Input>
                     <transaction_id>T18f97d9e-2f77-4126-a77e-eea92aabfab0</transaction_id>
                 </properties>
@@ -6866,7 +6866,7 @@
                 <Input>
                     <matcher>
                         <matcherType>ExactMatcher</matcherType>
-                        <matcherParameter name="single">It would be reasonable to expect that the mean number of sleep hours of students will be lower due to studying or partying…</matcherParameter>
+                        <matcherParameter name="single">It would be reasonable to expect that the mean number of sleep hours of students will be lower due to studying or partying&hellip;</matcherParameter>
                     </matcher>
                 </Input>
                 <Actor linkTriggered="false">Tutor (unevaluated)</Actor>

--- a/stattutor/public/problem_files/m4_cell_phones/cell_phones.brd
+++ b/stattutor/public/problem_files/m4_cell_phones/cell_phones.brd
@@ -5943,7 +5943,7 @@
                         <value>UpdateTextArea</value>
                     </Action>
                     <Input>
-                        <value>Both conditions under which we can reliably use the z-test for the population proportion are met:(i) The sample is random (recall that the sampling method used is cluster sampling)(ii) n = 312, and Po = .8 and so 312(.8) = 249.6 ≥ 10 and also 312(1-.8) = 62.4 ≥ 10.</value>
+                        <value>Both conditions under which we can reliably use the z-test for the population proportion are met:(i) The sample is random (recall that the sampling method used is cluster sampling)(ii) n = 312, and Po = .8 and so 312(.8) = 249.6 &ge; 10 and also 312(1-.8) = 62.4 &ge; 10.</value>
                     </Input>
                     <transaction_id>Tafceb1fc-54ab-4ce1-8710-5ebf69525543</transaction_id>
                 </properties>
@@ -5971,7 +5971,7 @@
                 <Input>
                     <matcher>
                         <matcherType>ExactMatcher</matcherType>
-                        <matcherParameter name="single">Both conditions under which we can reliably use the z-test for the population proportion are met:(i) The sample is random (recall that the sampling method used is cluster sampling)(ii) n = 312, and Po = .8 and so 312(.8) = 249.6 ≥ 10 and also 312(1-.8) = 62.4 ≥ 10.</matcherParameter>
+                        <matcherParameter name="single">Both conditions under which we can reliably use the z-test for the population proportion are met:(i) The sample is random (recall that the sampling method used is cluster sampling)(ii) n = 312, and Po = .8 and so 312(.8) = 249.6 &ge; 10 and also 312(1-.8) = 62.4 &ge; 10.</matcherParameter>
                     </matcher>
                 </Input>
                 <Actor linkTriggered="true">Tutor (unevaluated)</Actor>

--- a/stattutor/public/problem_files/m4_cell_phones/cell_phones.brd
+++ b/stattutor/public/problem_files/m4_cell_phones/cell_phones.brd
@@ -5943,7 +5943,7 @@
                         <value>UpdateTextArea</value>
                     </Action>
                     <Input>
-                        <value>Both conditions under which we can reliably use the z-test for the population proportion are met:(i) The sample is random (recall that the sampling method used is cluster sampling)(ii) n = 312, and Po = .8 and so 312(.8) = 249.6 &ge; 10 and also 312(1-.8) = 62.4 &ge; 10.</value>
+                        <value>Both conditions under which we can reliably use the z-test for the population proportion are met:(i) The sample is random (recall that the sampling method used is cluster sampling)(ii) n = 312, and Po = .8 and so 312(.8) = 249.6 &amp;ge; 10 and also 312(1-.8) = 62.4 &amp;ge; 10.</value>
                     </Input>
                     <transaction_id>Tafceb1fc-54ab-4ce1-8710-5ebf69525543</transaction_id>
                 </properties>
@@ -5971,7 +5971,7 @@
                 <Input>
                     <matcher>
                         <matcherType>ExactMatcher</matcherType>
-                        <matcherParameter name="single">Both conditions under which we can reliably use the z-test for the population proportion are met:(i) The sample is random (recall that the sampling method used is cluster sampling)(ii) n = 312, and Po = .8 and so 312(.8) = 249.6 &ge; 10 and also 312(1-.8) = 62.4 &ge; 10.</matcherParameter>
+                        <matcherParameter name="single">Both conditions under which we can reliably use the z-test for the population proportion are met:(i) The sample is random (recall that the sampling method used is cluster sampling)(ii) n = 312, and Po = .8 and so 312(.8) = 249.6 &amp;ge; 10 and also 312(1-.8) = 62.4 &amp;ge; 10.</matcherParameter>
                     </matcher>
                 </Input>
                 <Actor linkTriggered="true">Tutor (unevaluated)</Actor>
@@ -6838,7 +6838,7 @@
                         <value>UpdateTextArea</value>
                     </Action>
                     <Input>
-                        <value>It would be reasonable to expect that the mean number of sleep hours of students will be lower due to studying or partying&hellip;</value>
+                        <value>It would be reasonable to expect that the mean number of sleep hours of students will be lower due to studying or partying&amp;hellip;</value>
                     </Input>
                     <transaction_id>T18f97d9e-2f77-4126-a77e-eea92aabfab0</transaction_id>
                 </properties>
@@ -6866,7 +6866,7 @@
                 <Input>
                     <matcher>
                         <matcherType>ExactMatcher</matcherType>
-                        <matcherParameter name="single">It would be reasonable to expect that the mean number of sleep hours of students will be lower due to studying or partying&hellip;</matcherParameter>
+                        <matcherParameter name="single">It would be reasonable to expect that the mean number of sleep hours of students will be lower due to studying or partying&amp;hellip;</matcherParameter>
                     </matcher>
                 </Input>
                 <Actor linkTriggered="false">Tutor (unevaluated)</Actor>


### PR DESCRIPTION
It seems that XBlock does not like unicode characters. The changes in this branch convert the offending unicode characters to html entities in the m4 brd.
