### PR TITLE
Changes requested 2017-01-04 by Stanford.

### DIFF
--- a/stattutor/static/js/Initialize_CTATXBlock.js
+++ b/stattutor/static/js/Initialize_CTATXBlock.js
@@ -55,17 +55,31 @@ function Initialize_CTATXBlock(runtime,element)
 			if (ll!=null)
 			{
 				var lastSAI=ll.getLastSAI ();
+
+				var stepGrade = null;
+				var actionEval = aMessage.match(/%3Caction_evaluation[%0-9A-Za-z_]*%3E([A-Za-z ]+)%3C%2Faction_evaluation[%0-9A-F]*%3E/);
+				if(actionEval && actionEval.length>1)
+				{
+					var ae = actionEval[1].toLowerCase();
+					stepGrade=(ae.indexOf("hint") >= 0 ? 0.5 : (ae.indexOf("incorrect") >= 0 ? 0.0 : 1.0));
+				}
+				var postData = {event_type: 'ctat_log',
+						action: 'CTATlogevent',
+						problem_name: CTATConfig.problem_name,
+						dataset_name: CTATConfig.dataset_name,
+						problem_question_name: (CTATConfig.problem_name+'_'+lastSelection),
+						message: JSONDriver.xml_str2json (aMessage)};
+				if(stepGrade !== null)
+				{
+				    postData.event = {grade: stepGrade,
+						      max_grade: 1.0};
+				}
 					
 				$.ajax(
 				{
 					type: "POST",
 					url: runtime.handlerUrl(element, 'ctat_log'),
-					data: JSON.stringify({'event_type':'ctat_log',
-										'action':'CTATlogevent',
-										'problem_name' : CTATConfig.problem_name,
-										'dataset_name' : CTATConfig.dataset_name,
-										'problem_question_name' : (CTATConfig.problem_name+'_'+lastSelection),
-										'message': JSONDriver.xml_str2json (aMessage)}),
+					data: JSON.stringify(postData),
 					contentType: "application/json; charset=utf-8",
 					dataType: "json"
 				});

--- a/stattutor/stattutor.py
+++ b/stattutor/stattutor.py
@@ -229,7 +229,7 @@ class StattutorXBlock(XBlock):
         try:
             data['user_id'] = self.runtime.user_id
             data['component_id'] = unicode(self.scope_ids.usage_id)
-            self.runtime.publish(self, "ctatlog", data)
+            self.runtime.publish(self, "problem_check", data)
         # General mechanism to catch a very broad category of errors.
         except Exception as err:
             return {'result': 'fail', 'error': unicode(err)}


### PR DESCRIPTION
1. Change 'ctatlog' to 'problem_check' in statttutor.py:ctat_log(). 
2. Add a child 'event' with properties 'grade' and 'max_grade' to the ctat_log payload. This implementation adds the child only for ctat_log entries that include grades (tutor_messages, no context_ or tool_messages).